### PR TITLE
fix(client): 把 minimax-token-plan 也归到 Minimax 厂商

### DIFF
--- a/src/client/UsageBilling.tsx
+++ b/src/client/UsageBilling.tsx
@@ -198,10 +198,13 @@ const SUBSCRIPTION_VENDORS: Readonly<Record<string, string>> = {
   'baidu': '百度文心',
   'wenxin': '百度文心',
   'minimax': 'MiniMax',
+  'minimax-token-plan': 'MiniMax',
   'minimax-token-plan-cn': 'MiniMax',
   'opencode': 'OpenCode',
   'opencode-go': 'OpenCode',
 }
+/** Export the table only for tests; consumers should still go through {@link subscriptionVendorOf}. */
+export const SUBSCRIPTION_VENDORS_FOR_TEST: Readonly<Record<string, string>> = SUBSCRIPTION_VENDORS
 
 /** 订阅套餐归并到的厂商显示名；未知 id 回退为从 model id 反推或 id 本身。 */
 function subscriptionVendorOf(provider: string): string {

--- a/tests/subscription-vendors.spec.ts
+++ b/tests/subscription-vendors.spec.ts
@@ -1,0 +1,22 @@
+/**
+ * Subscription provider → vendor mapping: every subscription provider id
+ * that has a distinct display name from its existing siblings must be
+ * listed in SUBSCRIPTION_VENDORS, otherwise subscriptionVendorOf() falls
+ * through and the card lists the provider id verbatim in the "vendor"
+ * column, breaking the per-vendor aggregation.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { SUBSCRIPTION_VENDORS_FOR_TEST } from '../src/client/UsageBilling.tsx'
+
+describe('SUBSCRIPTION_VENDORS', () => {
+  it('maps every MiniMax subscription id to the MiniMax vendor', () => {
+    // 历史修复（见 PR #6）: v0.9.8 起 SUBSCRIPTION_VENDORS 漏掉了
+    // 'minimax-token-plan'，仅 'minimax' 与 'minimax-token-plan-cn' 列在其中，
+    // 导致用 'minimax-token-plan' 作 provider id 的部署在订阅卡片里被回退到
+    // 显示原始 id 而不是「MiniMax」。补全后三条 provider id 必须同口径映射。
+    expect(SUBSCRIPTION_VENDORS_FOR_TEST['minimax']).toBe('MiniMax')
+    expect(SUBSCRIPTION_VENDORS_FOR_TEST['minimax-token-plan']).toBe('MiniMax')
+    expect(SUBSCRIPTION_VENDORS_FOR_TEST['minimax-token-plan-cn']).toBe('MiniMax')
+  })
+})


### PR DESCRIPTION
### 摘要

`SUBSCRIPTION_VENDORS` 表里漏了 `'minimax-token-plan' → 'MiniMax'`（v0.9.8 起就这样，仅 `'minimax'` 与 `'minimax-token-plan-cn'` 在表里），用户把 provider id 注册成 `minimax-token-plan` 时订阅卡片"厂商"列会回退成原始 id。这条独立 PR 把这一行补全，让三个 MiniMax 提供方 id 走同一个厂商归并。

这条发现自 PR #5 review 阶段，scope 与 PR #5 "新增 minimax-token-plan-cn" 互不耦合，故独立提 PR。

### 改动

**`src/client/UsageBilling.tsx`**

- `SUBSCRIPTION_VENDORS` 加一行 `'minimax-token-plan': 'MiniMax'`。
- 末尾以 `export const SUBSCRIPTION_VENDORS_FOR_TEST = SUBSCRIPTION_VENDORS` 暴露给单测；`subscriptionVendorOf()` 内部 API 不变。

**`tests/subscription-vendors.spec.ts`（新增）**

- vitest 用例断言三个 MiniMax provider id 都归到 `'MiniMax'` 厂商。

### 行为差异

仅修正订阅卡片"厂商"列归组标签；不影响 `collectMiniMax`、baseUrl 选择、displayName 等其它路径。

| provider id（用户配置） | v0.9.9 之前"厂商"列 | 本 PR 之后 |
| --- | --- | --- |
| `minimax` | `MiniMax` | `MiniMax` |
| `minimax-token-plan` | `minimax-token-plan`（id 字面） | `MiniMax` |
| `minimax-token-plan-cn` | `MiniMax`（PR #5 已修） | `MiniMax` |

### 测试

- 新增 `tests/subscription-vendors.spec.ts` 1 条用例。
- 已在本地 vitest 跑通：
  ```
  ✓ tests/subscription-vendors.spec.ts  (1 test)
  ✓ tests/subscriptions.spec.ts         (16 tests)
  ✓ tests/plan-knowledge.spec.ts        (11 tests)
  Tests  28 passed (28)
  ```
- 验证环境用 vitest 2.0.0 + 自定义 `resolve.alias` 把 monorepo workspace 包 (`@deepseek-ai/*`) 替换成 stub 来通过 transform 阶段，这与上游 CI 上用 monorepo 真包相比不影响断言行为。

### 配套

- 配套 fix 见 PR #5。
- 本 PR 仅新增/修改上述 2 个文件，**不**触碰 PR #5 的 `src/subscriptions.ts`、`src/client/plan-knowledge.ts`、`src/client/provider-display.ts`。
