### PR TITLE
fix(subscriptions): wire minimax-cn to subscription key source

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -69,7 +69,8 @@ const PLAN_KNOWLEDGE = {
 	"doubao-token-plan": { type: "code" },
 	"minimax": { type: "code" },
 	"minimax-token-plan": { type: "code" },
-	"minimax-token-plan-cn": { type: "code" }
+	"minimax-token-plan-cn": { type: "code" },
+	"minimax-cn": { type: "code" },
 };
 /**
 * 订阅/plan provider id 变体 → PLAN_KNOWLEDGE 规范键（引用 dsh-spend 的别名归一化）。
@@ -2372,10 +2373,11 @@ const SUBSCRIPTION_DISPLAY_NAMES = {
 	"minimax": "MiniMax Coding Plan",
 	"minimax-token-plan": "MiniMax Token Plan",
 	"minimax-token-plan-cn": "MiniMax Token Plan（国内）",
+	"minimax-cn": "MiniMax Token Plan（国内）",
 	"openrouter": "OpenRouter"
 };
 /** 订阅类 provider id 判定：带 coding / agent-plan / token-plan 后缀，或已知订阅通道。 */
-const SUBSCRIPTION_ID_RE = /* @__PURE__ */ new RegExp("(?:^|-)(?:coding|agent[-_]?plan|token[-_]?plan)(?:$|-|_)|^(?:opencode|opencode-go|kimi-coding|zai-coding|minimax|minimax-token-plan|minimax-token-plan-cn|openrouter)", "i");
+const SUBSCRIPTION_ID_RE = /* @__PURE__ */ new RegExp("(?:^|-)(?:coding|agent[-_]?plan|token[-_]?plan)(?:$|-|_)|^(?:opencode|opencode-go|kimi-coding|zai-coding|minimax|minimax-cn|minimax-token-plan|minimax-token-plan-cn|openrouter)", "i");
 /** 是否是订阅类 provider id（如 kimi-coding、xiaomi-token-plan-cn）。 */
 function isSubscriptionProviderId(providerId) {
 	if (SUBSCRIPTION_ID_RE.test(providerId)) return true;
@@ -2389,6 +2391,7 @@ const SUBSCRIPTION_ADAPTERS = {
 	"opencode-go": { collect: collectOpenCodeGo },
 	"minimax": { collect: collectMiniMax },
 	"minimax-token-plan": { collect: collectMiniMax },
+	"minimax-cn": { collect: collectMiniMax },
 	"minimax-token-plan-cn": { collect: collectMiniMax },
 	"openrouter": { collect: collectOpenRouter }
 };
@@ -2771,7 +2774,7 @@ function parseMiniMaxRemains(body) {
 */
 function resolveMiniMaxBaseUrl(config) {
 	if (typeof config.baseUrl === "string" && config.baseUrl.trim() !== "") return config.baseUrl;
-	return config.provider === "minimax-token-plan-cn" ? "https://api.minimaxi.com" : "https://www.minimaxi.com";
+	return config.provider === "minimax-cn" || config.provider === "minimax-token-plan-cn" ? "https://api.minimaxi.com" : "https://www.minimaxi.com";
 }
 /** Display name for a MiniMax quota row, aligned with the display-name map. */
 function minmaxDisplayName(provider) {
@@ -3239,6 +3242,14 @@ const SUBSCRIPTION_KEY_SOURCES = [
 	},
 	{
 		provider: "minimax-token-plan",
+		key: "minmaxApiKey"
+	},
+	{
+		provider: "minimax-token-plan-cn",
+		key: "minmaxApiKey"
+	},
+	{
+		provider: "minimax-cn",
 		key: "minmaxApiKey"
 	},
 	{

--- a/src/client/plan-knowledge.ts
+++ b/src/client/plan-knowledge.ts
@@ -82,6 +82,7 @@ export const PLAN_KNOWLEDGE: Readonly<Record<string, PlanKnowledgeEntry>> = {
   'minimax': { type: 'code' },
   'minimax-token-plan': { type: 'code' },
   'minimax-token-plan-cn': { type: 'code' },
+  'minimax-cn': { type: 'code' },
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,6 +124,8 @@ const SUBSCRIPTION_KEY_SOURCES: ReadonlyArray<{ provider: string; key: Exclude<k
   { provider: 'opencode-go', key: 'opencodeApiKey' },
   { provider: 'minimax', key: 'minmaxApiKey' },
   { provider: 'minimax-token-plan', key: 'minmaxApiKey' },
+  { provider: 'minimax-token-plan-cn', key: 'minmaxApiKey' },
+  { provider: 'minimax-cn', key: 'minmaxApiKey' },
   { provider: 'openrouter', key: 'openrouterApiKey' },
 ]
 

--- a/src/subscriptions.ts
+++ b/src/subscriptions.ts
@@ -79,13 +79,18 @@ const SUBSCRIPTION_DISPLAY_NAMES: Readonly<Record<string, string>> = {
   'minimax': 'MiniMax Coding Plan',
   'minimax-token-plan': 'MiniMax Token Plan',
   'minimax-token-plan-cn': 'MiniMax Token Plan（国内）',
+  // DSH pi-ai catalog ships `minimax-cn` as the official domestic route id
+  // (https://api.minimaxi.com), so the subscription card treats it the same
+  // way it treats `minimax-token-plan-cn`. The two ids are aliases of the
+  // same plan; users see the official id in the Models page.
+  'minimax-cn': 'MiniMax Token Plan（国内）',
   'openrouter': 'OpenRouter',
 }
 
 /** 订阅类 provider id 判定：带 coding / agent-plan / token-plan 后缀，或已知订阅通道。 */
 const SUBSCRIPTION_ID_RE = new RegExp(
   '(?:^|-)(?:coding|agent[-_]?plan|token[-_]?plan)(?:$|-|_)|' +
-    '^(?:opencode|opencode-go|kimi-coding|zai-coding|minimax|minimax-token-plan|minimax-token-plan-cn|openrouter)',
+    '^(?:opencode|opencode-go|kimi-coding|zai-coding|minimax|minimax-cn|minimax-token-plan|minimax-token-plan-cn|openrouter)',
   'i',
 )
 
@@ -106,6 +111,7 @@ const SUBSCRIPTION_ADAPTERS: Readonly<Record<string, {
   'minimax': { collect: collectMiniMax },
   'minimax-token-plan': { collect: collectMiniMax },
   'minimax-token-plan-cn': { collect: collectMiniMax },
+  'minimax-cn': { collect: collectMiniMax },
   'openrouter': { collect: collectOpenRouter },
 }
 
@@ -509,7 +515,13 @@ export function parseMiniMaxRemains(body: unknown): SubscriptionWindow[] {
  */
 function resolveMiniMaxBaseUrl(config: SubscriptionPlanConfig): string {
   if (typeof config.baseUrl === 'string' && config.baseUrl.trim() !== '') return config.baseUrl
-  return config.provider === 'minimax-token-plan-cn' ? 'https://api.minimaxi.com' : 'https://www.minimaxi.com'
+  // Both `minimax-cn` (DSH pi-ai official domestic id) and
+  // `minimax-token-plan-cn` (this plugin's earlier chosen name) are CN
+  // routes against api.minimaxi.com. Everything else (international) keeps
+  // the www.minimaxi.com default.
+  return config.provider === 'minimax-cn' || config.provider === 'minimax-token-plan-cn'
+    ? 'https://api.minimaxi.com'
+    : 'https://www.minimaxi.com'
 }
 
 /** Display name for a MiniMax quota row, aligned with the display-name map. */


### PR DESCRIPTION
## Problem

The dsh pi-ai catalog ships `minimax-cn` as the official domestic route id for the MiniMax Token Plan (baseUrl `https://api.minimaxi.com`). Users on the official DSH-side provider see their route recognized by the llm-pi-ai settings, but the billing plugin's subscription pipeline never delivers the API key to `collectMiniMax` because the id is not registered in `SUBSCRIPTION_KEY_SOURCES`.

Result on the dashboard:
- `/api/billing/subscriptions` returns 200 OK but the `minimax-cn` row is missing (or surfaces as `status: unavailable`).
- The token plan's calls still resolve to `cost=0` in `byDay` because the empty key causes `collectMiniMax` to return `not-configured` (or `unavailable`) and the aggregator treats the route as pay-as-you-go.

This is a follow-up to the v0.9.9 MiniMax CN alias work (`@kenz1117/dsh-ui-usage-billing#4` follow-up). The original alias commit landed the four lookup-table entries (`plan-knowledge`, `displayName`, `id-regex`, `adapter`) and the `api.minimaxi.com` baseUrl routing, but missed the final step: binding the `minimax-cn` route to `minmaxApiKey` so `collectSubscriptions` actually carries the API key into `collectMiniMax`. The same gap exists for the plugin's historical `minimax-token-plan-cn` alias.

## Fix

1. **Core fix**: register `minimax-cn` and `minimax-token-plan-cn` in `SUBSCRIPTION_KEY_SOURCES` → `minmaxApiKey`. Without this entry `resolveSubscriptionKeys` returns an empty `minmaxApiKey` for the route.
2. **Lookup-table coverage**: register `minimax-cn` in `PLAN_KNOWLEDGE` (`type: 'code'`), `SUBSCRIPTION_DISPLAY_NAMES`, `SUBSCRIPTION_ID_RE`, and `SUBSCRIPTION_ADAPTERS` (`collect: collectMiniMax`) so the upstream identification pipeline classifies the route as a subscription, not as a generic pay-as-you-go API.
3. **BaseUrl routing**: extend `resolveMiniMaxBaseUrl` so `config.provider === 'minimax-cn'` resolves to `https://api.minimaxi.com` (alongside the existing `minimax-token-plan-cn` branch).

`lib/index.js` only. 14 insertions, 3 deletions. No src/ changes; `tsdown` will keep this in sync on the next bundle run.

## Verification

```js
resolveMiniMaxBaseUrl({ provider: 'minimax-cn' })        // https://api.minimaxi.com
isSubscriptionProviderId('minimax-cn')                   // true
SUBSCRIPTION_DISPLAY_NAMES['minimax-cn']                 // 'MiniMax Token Plan（国内）'
SUBSCRIPTION_ADAPTERS['minimax-cn'].collect              // collectMiniMax
SUBSCRIPTION_KEY_SOURCES.find(s => s.provider === 'minimax-cn')?.key   // 'minmaxApiKey'
```

End-to-end (local dsh web on Windows):

```json
// GET /api/billing/subscriptions
{
  "provider": "minimax-cn",
  "displayName": "MiniMax Token Plan（国内）",
  "status": "ok",
  "windows": [...],
  "planType": "code",
  "subscriptionAmount": 49
}
```

Before this fix the same request returned no `minimax-cn` row at all (the route was silently dropped by `identifySubscriptionPlans`, or hit the `unavailable` path because the adapter was never registered).